### PR TITLE
Update and rename lng_zh-TW.json to lng_zh-Hant.json

### DIFF
--- a/overlay/emuiibo/lng_zh-Hant.json
+++ b/overlay/emuiibo/lng_zh-Hant.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
         "base": "en",
-        "language": "zh-TW",
+        "language": "zh-Hant",
         "created": "2021-11-2",
         "author": "qazrfv1234"
     },


### PR DESCRIPTION
zh-Hant is the correct language code for Traditional Chinese